### PR TITLE
Update node-hid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/somebuddy87/node-red-contrib-usbhid.git"
   },
   "dependencies": {
-    "node-hid": "^0.5.1"
+    "node-hid": "^0.7.7"
    },
   "node-red": {
     "nodes": {


### PR DESCRIPTION
Update the dependency on node-hid to its latest version (0.7.7).